### PR TITLE
Toggle between push() and replace() for router navigation method

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -209,7 +209,7 @@ const SpaceArrayDatatype = separatedArrayDatatype(' ')
 
 const QuerySynchronizer = {
 
-    install(Vue, { router, datatypes, debug }) {
+    install(Vue, { router, datatypes, debug, replace }) {
         datatypes = {
             'string': StringDatatype,
             'bool': BoolDatatype,
@@ -230,6 +230,11 @@ const QuerySynchronizer = {
                 d[1].code = d[0]
             })
         }
+        
+        // selected router navigation method
+        const navMethod = replace
+            ? 'replace'
+            : 'push'
 
         const _vue = new Vue({
             data: {
@@ -429,7 +434,7 @@ const QuerySynchronizer = {
             if (_vue.settings.onChange) {
                 _vue.settings.onChange(newQuery, query, _vue)
             }
-            router.push({ query: newQuery })
+            router[navMethod]({ query: newQuery })
         })
     }
 }


### PR DESCRIPTION
Adding the option to select `replace()` as the router navigation method, for cases where you don't want to keep the query changes in history.