### PR TITLE
Support navigationOperation option in Vue 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ Vue.use(QuerySynchronizer, {
     datatypes: {
         name: handler
     },
-    debug: false
+    debug: false,
+    navigationOperation: 'push' | 'replace',
 })
 ```
 

--- a/src/library.js
+++ b/src/library.js
@@ -209,7 +209,7 @@ const SpaceArrayDatatype = separatedArrayDatatype(' ')
 
 const QuerySynchronizer = {
 
-    install(Vue, { router, datatypes, debug }) {
+    install(Vue, { router, datatypes, debug, navigationOperation }) {
         datatypes = {
             'string': StringDatatype,
             'bool': BoolDatatype,
@@ -230,6 +230,9 @@ const QuerySynchronizer = {
                 d[1].code = d[0]
             })
         }
+        
+        // selected router navigation method
+        const navMethod = navigationOperation || 'push'
 
         const _vue = new Vue({
             data: {
@@ -429,7 +432,7 @@ const QuerySynchronizer = {
             if (_vue.settings.onChange) {
                 _vue.settings.onChange(newQuery, query, _vue)
             }
-            router.push({ query: newQuery })
+            router[navMethod]({ query: newQuery })
         })
     }
 }

--- a/src/library.js
+++ b/src/library.js
@@ -412,7 +412,8 @@ const QuerySynchronizer = {
             if (Object.keys(existingQuery).length === Object.keys(newQuery).length) {
                 for (const k of Object.keys(newQuery)) {
                     const val = newQuery[k] !== null ? newQuery[k].toString() : null
-                    if (val !== existingQuery[k].toString()) {
+                    const existingVal = existingQuery[k] !== null && existingQuery[k] !== undefined ? existingQuery[k].toString() : null
+                    if (val !== existingVal) {
                         if (debug) {
                             console.log('Setting router from query: modified property', k, val, existingQuery[k])
                         }


### PR DESCRIPTION
You might recognise this, it's @omnichronous's https://github.com/oarepo/vue-query-synchronizer/pull/9 but I've matched it to your Vue 3 API and based it against the `vue-2` branch.

> Adds the option to select `replace` as the router navigation method, for cases where you don't want to keep the query changes in history.

I've updated the README, I didn't bother adding support for passing callback.

LGTM?